### PR TITLE
change processing tests to use multiprocess

### DIFF
--- a/pysilcam/tests/test_process.py
+++ b/pysilcam/tests/test_process.py
@@ -51,7 +51,7 @@ def test_output_files():
         os.remove(hdf_file)
 
     # call process function
-    silcam_process(conf_file_out, data_file, multiProcess=False)
+    silcam_process(conf_file_out, data_file, multiProcess=True)
 
     # check that csv file has been created
     assert os.path.isfile(stats_file), ('STATS csv file not created. should be here:' + stats_file)

--- a/pysilcam/tests/test_standards.py
+++ b/pysilcam/tests/test_standards.py
@@ -38,7 +38,7 @@ def test_big_standards():
         os.remove(stats_file)
 
     # call process function
-    silcam_process(conf_file_out, data_file, multiProcess=False, nbImages=10)
+    silcam_process(conf_file_out, data_file, multiProcess=True, nbImages=10)
 
     # check that csv file has been created
     assert os.path.isfile(stats_file), 'stats_file not created'
@@ -86,7 +86,7 @@ def test_small_standards():
         os.remove(stats_file)
 
     # call process function
-    silcam_process(conf_file_out, data_file, multiProcess=False, nbImages=10)
+    silcam_process(conf_file_out, data_file, multiProcess=True, nbImages=10)
 
     # check that csv file has been created
     assert os.path.isfile(stats_file), 'stats_file not created'


### PR DESCRIPTION
Now we have tests running from Docker, we can enable multiprocessing for the tests of processing the unittest data.

This will probably cause issues for windows users who want to test the unittest dataset locally because of a known issue with multiprocess and pytest on windows. However, I think it is more important to have the mulriprocessing code tested now that we have that capability.