### PR TITLE
Added linting with Lintly (flake8)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 130
+max-complexity = 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Run linting on the Python codebase
+
+on: [pull_request] # Lintly runs only on Pull Requests
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Perform linting
+        uses: grantmcconnaughey/lintly-flake8-github-action@v1.0
+        with:
+          # The GitHub API token to create reviews with
+          token: ${{ secrets.API_TOKEN_LINTLY }}
+          # Fail if "new" violations detected or "any", default "new"
+          failIf: any
+          # Additional arguments to pass to flake8 can be passed using "args", which defaults to "." (current directory)
+          # Note that flake8 already uses repository defaults from the .flake8 configuration file.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
           # The GitHub API token to create reviews with
           token: ${{ secrets.API_TOKEN_LINTLY }}
           # Fail if "new" violations detected or "any", default "new"
-          failIf: any
+          failIf: new
           # Additional arguments to pass to flake8 can be passed using "args", which defaults to "." (current directory)
           # Note that flake8 already uses repository defaults from the .flake8 configuration file.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ If you want to mount a local folder inside the docker environment, use -v [local
 docker-compose run -v /mnt/ARRAY/:/mnt/ARRAY/ --rm --entrypoint /bin/bash silcam
 ```
 
+Contributions
+-------------
+
+We welcome additions and improvements to the code!
+
+However, we also request that you follow a few guidelines. These are in place to make sure the code improves over time.
+
+1. All code changes must be submitted as pull requests, either from a branch or a fork.
+2. All pull requests are required to pass all tests. Please do not disable or remove tests just to make your branch pass the pull request.
+3. All pull requests must be reviewed by a person. The benefits from code review are plenty, but we like to emphasise that code reviews help spreading the awarenes of code changes. Please note that code reviews should be a pleasant experience, so be plesant, polite and remember that there is a human being with good intentions on the other side of the screen.
+4. All contributions are linted with flake8. We recommend that you run flake8 on your code while developing to fix any issues as you go.
+5. We recommend using autopep8 to autoformat your Python code. This makes flake8 happy, and makes it easier for us all to maintain a consistent and readable code base.
+
 License
 -------
 

--- a/pysilcam/tests/test_process.py
+++ b/pysilcam/tests/test_process.py
@@ -38,9 +38,9 @@ def test_output_files():
     conf.write(conf_file_hand)
     conf_file_hand.close()
 
-    stats_file = os.path.join(data_file,'proc', 'STN04-STATS.csv')
-    hdf_file = os.path.join(data_file,'export/D20170509T172705.387171.h5')
-    report_figure = os.path.join(data_file,'proc', 'STN04-Summary_all.png')
+    stats_file = os.path.join(data_file, 'proc', 'STN04-STATS.csv')
+    hdf_file = os.path.join(data_file, 'export/D20170509T172705.387171.h5')
+    report_figure = os.path.join(data_file, 'proc', 'STN04-Summary_all.png')
 
     # if csv file already exists, it has to be deleted
     if (os.path.isfile(stats_file)):

--- a/pysilcam/tests/test_process.py
+++ b/pysilcam/tests/test_process.py
@@ -38,8 +38,8 @@ def test_output_files():
     conf.write(conf_file_hand)
     conf_file_hand.close()
 
-    stats_file = os.path.join(data_file, 'proc', 'STN04-STATS.csv')
-    hdf_file = os.path.join(data_file, 'export/D20170509T172705.387171.h5')
+    stats_file = os.path.join(data_file,'proc', 'STN04-STATS.csv')
+    hdf_file = os.path.join(data_file,'export/D20170509T172705.387171.h5')
     report_figure = os.path.join(data_file,'proc', 'STN04-Summary_all.png')
 
     # if csv file already exists, it has to be deleted


### PR DESCRIPTION
This pull request adds a flake8 linting action to pull requests. This is configured to a maximum line length of 130, and only trigger on new issues (or, issues in changed code lines). This means that we can introduce it and improve the Python code over time.

Note that most style changes that will trigger flake8 can be easilly fixed by running autopep8, and this should therefore be a recommended practice.

I've added a Contributor section to the README.md including this.

I also added two changes that should trigger the linting, just to illustrate how it will capture and highlight this in the pull request.

Please note that the linter presently uses my account key to do the lint replies, this could be made by a bot user in the future.