### PR TITLE
GitHub action timeout

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
       - name: Check out code

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 30
 
     steps:
       - name: Check out code


### PR DESCRIPTION
This will cause the Docker build and test job to be cancelled if it does not complete within 30 minutes. This might be needed to catch issues that cause the tests to hang indefinitely.