### PR TITLE
include check for classification model path before processing

### DIFF
--- a/pysilcam/__main__.py
+++ b/pysilcam/__main__.py
@@ -240,6 +240,8 @@ def silcam_process(config_filename, datapath, multiProcess=True, realtime=False,
     datafilename = os.path.join(settings.General.datafile, procfoldername)
     logger.info('output stats to: ' + datafilename)
 
+    sccl.check_model(settings.NNClassify.model_path)
+
     adminSTATS(logger, settings, overwriteSTATS, datafilename, datapath)
 
     # Initialize the image acquisition generator

--- a/pysilcam/silcam_classify.py
+++ b/pysilcam/silcam_classify.py
@@ -15,6 +15,24 @@ import os
 SilCam TensorFlow analysis for classification of particle types
 '''
 
+def check_model(model_path):
+    '''
+    Raises errors if classification model is not found
+
+    Args:
+        model_path (str)        : path to particle-classifier e.g.
+                                  '/mnt/ARRAY/classifier/model/particle-classifier.tfl'
+                                  usually obtained from settings.NNClassify.model_path
+
+    '''
+    path, filename = os.path.split(model_path)
+    if os.path.exists(path) is False:
+        raise Exception(path + ' not found')
+
+    header_file = os.path.join(path, 'header.tfl.txt')
+    if os.path.isfile(header_file) is False:
+        raise Exception(header_file + ' not found')
+
 
 def get_class_labels(model_path='/mnt/ARRAY/classifier/model/particle-classifier.tfl'):
     '''
@@ -23,6 +41,7 @@ def get_class_labels(model_path='/mnt/ARRAY/classifier/model/particle-classifier
     Args:
         model_path (str)        : path to particle-classifier e.g.
                                   '/mnt/ARRAY/classifier/model/particle-classifier.tfl'
+                                  usually obtained from settings.NNClassify.model_path
 
     Returns:
         class_labels (str)      : labelled catagories which can be predicted

--- a/pysilcam/silcam_classify.py
+++ b/pysilcam/silcam_classify.py
@@ -15,6 +15,7 @@ import os
 SilCam TensorFlow analysis for classification of particle types
 '''
 
+
 def check_model(model_path):
     '''
     Raises errors if classification model is not found

--- a/pysilcam/tests/test_z_classify.py
+++ b/pysilcam/tests/test_z_classify.py
@@ -1,4 +1,4 @@
-from pysilcam.silcam_classify import load_model, predict
+from pysilcam.silcam_classify import check_model, load_model, predict
 from skimage.io import imread
 import glob
 import os
@@ -28,6 +28,8 @@ def test_classify():
 
     # location of the training data
     database_path = os.path.join(ROOTPATH, 'silcam_classification_database')
+
+    check_model(MODEL_PATH)
 
     # a tensorflow session must be started on each process in order to function reliably in multiprocess.
     # This also includes the import of tensorflow on each process


### PR DESCRIPTION
If the classification model path is incorrect, processing will just hang with no explanation. Now, checking of this path is performed before processing starts to raise an error if it does not exist.