### PR TITLE
Update Dockerfile to use Miniconda instead of full Anaconda image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use the Anaconda Docker image
-FROM continuumio/anaconda3:5.3.0
+#FROM continuumio/anaconda3:5.3.0
+FROM continuumio/miniconda3
 
 # Install build tools, gcc etc
 RUN apt-get update && apt-get install -y build-essential vim htop procps x11vnc xvfb libsdl-ttf2.0-0


### PR DESCRIPTION
Using miniconda can reduce the total disk space needed for the testing action. 