### PR TITLE
Macos bugfixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,8 @@ channels:
     - cogsci     # Channel for pygame
 dependencies:    # These are the conda packages
     - python=3.5
+    - pip=10.0.1
+    - libffi=3.2.1
     - numpy=1.15.2
     - scipy=1.0.0
     - pandas=0.20.3

--- a/pysilcam/__main__.py
+++ b/pysilcam/__main__.py
@@ -172,7 +172,7 @@ def silcam_acquire(datapath, config_filename, writeToDisk=True, gui=None):
         t1 = time.time()
 
         if gui is not None:
-            while not gui.empty():
+            while (gui.qsize() > 0):
                 try:
                     gui.get_nowait()
                     time.sleep(0.001)
@@ -321,7 +321,7 @@ def silcam_process(config_filename, datapath, multiProcess=True, realtime=False,
 
             if gui is not None:
                 logger.debug('Putting data on GUI Queue')
-                while not gui.empty():
+                while (gui.qsize() > 0):
                     try:
                         gui.get_nowait()
                         time.sleep(0.001)
@@ -382,7 +382,7 @@ def silcam_process(config_filename, datapath, multiProcess=True, realtime=False,
             if gui is not None:
                 collect_rts(settings, rts, stats_all)
                 logger.debug('Putting data on GUI Queue')
-                while not gui.empty():
+                while gui.qsize() > 0:
                     try:
                         gui.get_nowait()
                         time.sleep(0.001)
@@ -577,7 +577,7 @@ def collector(inputQueue, outputQueue, datafilename, proc_list, testInputQueue,
 
     countProcessFinished = 0
 
-    while (not outputQueue.empty()) or (testInputQueue and not inputQueue.empty()):
+    while ((outputQueue.qsize() > 0) or (testInputQueue and inputQueue.qsize() > 0)):
 
         task = outputQueue.get()
 

--- a/pysilcam/__main__.py
+++ b/pysilcam/__main__.py
@@ -172,7 +172,7 @@ def silcam_acquire(datapath, config_filename, writeToDisk=True, gui=None):
         t1 = time.time()
 
         if gui is not None:
-            while (gui.qsize() > 0):
+            while not gui.empty():
                 try:
                     gui.get_nowait()
                     time.sleep(0.001)
@@ -321,7 +321,7 @@ def silcam_process(config_filename, datapath, multiProcess=True, realtime=False,
 
             if gui is not None:
                 logger.debug('Putting data on GUI Queue')
-                while (gui.qsize() > 0):
+                while not gui.empty():
                     try:
                         gui.get_nowait()
                         time.sleep(0.001)
@@ -382,7 +382,7 @@ def silcam_process(config_filename, datapath, multiProcess=True, realtime=False,
             if gui is not None:
                 collect_rts(settings, rts, stats_all)
                 logger.debug('Putting data on GUI Queue')
-                while gui.qsize() > 0:
+                while not gui.empty():
                     try:
                         gui.get_nowait()
                         time.sleep(0.001)
@@ -577,7 +577,7 @@ def collector(inputQueue, outputQueue, datafilename, proc_list, testInputQueue,
 
     countProcessFinished = 0
 
-    while ((outputQueue.qsize() > 0) or (testInputQueue and inputQueue.qsize() > 0)):
+    while (not outputQueue.empty()) or (testInputQueue and not inputQueue.empty()):
 
         task = outputQueue.get()
 


### PR DESCRIPTION
Changes to the environment.yml to make pysilcam more compatible with mac os. Should also be more stable on other os's since the version of pip is specified.

Note: This branch is now kind of poorly named, as it doesn't actually allow pysilcam to run on macos, (since the `qsize()` method of multiprocessing doens't work on mac, and the `empty()` method doesn't work on linux). It could simply be run without multiprocessing, is someone just wants to run it on a mac.