### PR TITLE
setup file now specifies gui as a console script 93

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,6 @@ setup(
             'silcam = pysilcam.__main__:silcam',
             'silcam-report = pysilcam.silcreport:silcreport',
             'silcam-track = pysilcam.tracking.track:silctrack',
-        ],
-        'gui_scripts': [
             'silcam-gui = pysilcam.silcamgui.silcamgui:main',
         ]
     },


### PR DESCRIPTION
Fixes #93 by defining silcam-gui as a console script instead of gui script.